### PR TITLE
feat: add vault login helpers for fish shell

### DIFF
--- a/dot_config/fish/completions/vault.fish
+++ b/dot_config/fish/completions/vault.fish
@@ -1,0 +1,8 @@
+
+function __complete_vault
+    set -lx COMP_LINE (commandline -cp)
+    test -z (commandline -ct)
+    and set COMP_LINE "$COMP_LINE "
+    /usr/local/bin/vault
+end
+complete -f -c vault -a "(__complete_vault)"

--- a/dot_config/fish/conf.d/vault.fish.tmpl
+++ b/dot_config/fish/conf.d/vault.fish.tmpl
@@ -1,0 +1,30 @@
+# Clear inherited (global) VAULT_ADDR so universal variable takes precedence
+# (fixes VS Code/Cursor terminals inheriting stale values from parent process)
+set -eg VAULT_ADDR 2>/dev/null
+
+{{ if and .sensitive.VAULT_ADDR_STG .sensitive.VAULT_ADDR_PROD -}}
+# Stage vault login
+function vls
+    __vault_login "{{ .sensitive.VAULT_ADDR_STG }}" stage stg $argv
+end
+
+# Production vault login
+function vlp
+    __vault_login "{{ .sensitive.VAULT_ADDR_PROD }}" prod prd $argv
+end
+{{ else -}}
+# Vault URLs not configured - show helpful error
+function vls
+    echo "Error: VAULT_ADDR_STG not configured in chezmoi"
+    echo "Add to ~/.config/chezmoi/chezmoi.toml under [data.sensitive]:"
+    echo '  VAULT_ADDR_STG = "https://your-staging-vault.example.com"'
+    return 1
+end
+
+function vlp
+    echo "Error: VAULT_ADDR_PROD not configured in chezmoi"
+    echo "Add to ~/.config/chezmoi/chezmoi.toml under [data.sensitive]:"
+    echo '  VAULT_ADDR_PROD = "https://your-prod-vault.example.com"'
+    return 1
+end
+{{ end -}}

--- a/dot_config/fish/functions/__vault_login.fish
+++ b/dot_config/fish/functions/__vault_login.fish
@@ -1,0 +1,83 @@
+# Helper function for smart vault login
+function __vault_login
+    set -l vault_url $argv[1]
+    set -l env_name $argv[2]
+    set -l env_suffix $argv[3]
+
+    # Check for force flag
+    set -l force_login 0
+    if contains -- --force $argv; or contains -- -f $argv
+        set force_login 1
+    end
+
+    # Save current tokens before switching (vault uses both .vault-token and .vault-token.json)
+    if test -f ~/.vault-token
+        if string match -q "*stg*" "$VAULT_ADDR"
+            cp ~/.vault-token ~/.vault-token.stg
+            test -f ~/.vault-token.json; and cp ~/.vault-token.json ~/.vault-token.json.stg
+        else if string match -q "*prod*" "$VAULT_ADDR"
+            cp ~/.vault-token ~/.vault-token.prd
+            test -f ~/.vault-token.json; and cp ~/.vault-token.json ~/.vault-token.json.prd
+        end
+    end
+
+    # Clear ALL scopes to prevent shadowing, then set universal
+    set -e VAULT_ADDR 2>/dev/null
+    set -eU VAULT_ADDR 2>/dev/null
+    set -Ux VAULT_ADDR $vault_url
+    echo "VAULT_ADDR=$VAULT_ADDR"
+
+    # Restore cached tokens for this environment (both files)
+    if test -f ~/.vault-token.$env_suffix
+        cp ~/.vault-token.$env_suffix ~/.vault-token
+        test -f ~/.vault-token.json.$env_suffix; and cp ~/.vault-token.json.$env_suffix ~/.vault-token.json
+    else
+        # No cached token - remove .json so vault doesn't use stale one
+        rm -f ~/.vault-token.json
+    end
+
+    # Force login if requested
+    if test "$force_login" -eq 1
+        echo "Force login requested..."
+        __vault_do_oidc_login $env_suffix
+        return $status
+    end
+
+    # Check token TTL
+    set -l ttl (vault token lookup -format json 2>/dev/null | jq -r '.data.ttl' 2>/dev/null)
+
+    if test -z "$ttl" -o "$ttl" = "null"
+        echo "No valid token found, logging in..."
+        __vault_do_oidc_login $env_suffix
+    else if test "$ttl" -le 1800
+        echo "Token expires in <30 min ($ttl s), renewing..."
+        if vault token renew >/dev/null 2>&1
+            echo "Token renewed"
+            __vault_cache_token $env_suffix
+        else
+            echo "Renewal failed, doing OIDC login..."
+            __vault_do_oidc_login $env_suffix
+        end
+    else
+        set -l hours (math -s0 "$ttl / 3600")
+        set -l minutes (math -s0 "($ttl % 3600) / 60")
+        echo "Token valid: "$hours"h "$minutes"m"
+    end
+end
+
+function __vault_do_oidc_login
+    set -l env_suffix $argv[1]
+    if vault login -method=oidc
+        __vault_cache_token $env_suffix
+        return 0
+    else
+        echo "Login failed"
+        return 1
+    end
+end
+
+function __vault_cache_token
+    set -l env_suffix $argv[1]
+    cp ~/.vault-token ~/.vault-token.$env_suffix
+    test -f ~/.vault-token.json; and cp ~/.vault-token.json ~/.vault-token.json.$env_suffix
+end


### PR DESCRIPTION
Add vls/vlp commands for staging/production vault login with:

- Smart token caching per environment (stg/prd)

- Automatic token renewal when TTL is low

- Force login flag (-f/--force)

- OIDC authentication support

- Chezmoi templating for vault URLs

- Shell completions for vault command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shell command completion for Vault CLI
  * Introduced new commands for seamless authentication to staging and production Vault environments
  * Implemented intelligent token caching and automatic renewal based on token expiration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->